### PR TITLE
refactor(version-management): 移除 LLM 安装向导按钮及相关状态

### DIFF
--- a/src/renderer/components/VersionManagementPage.tsx
+++ b/src/renderer/components/VersionManagementPage.tsx
@@ -37,7 +37,7 @@ import {
 } from '../store/thunks/webServiceThunks';
 import type { RootState } from '../store';
 import { PackageSourceSelector } from './PackageSourceSelector';
-import { InstallationWizard } from './installation-wizard';
+
 
 interface Version {
   id: string;
@@ -115,7 +115,7 @@ export default function VersionManagementPage() {
   const [reinstallDialogOpen, setReinstallDialogOpen] = useState(false);
   const [uninstallDialogOpen, setUninstallDialogOpen] = useState(false);
   const [pendingVersionId, setPendingVersionId] = useState<string | null>(null);
-  const [llmWizardOpen, setLlmWizardOpen] = useState(false);
+
 
   useEffect(() => {
     fetchAllData();
@@ -514,16 +514,6 @@ export default function VersionManagementPage() {
           </div>
         </div>
 
-        {/* Claude Installation Button */}
-        <div className="mt-4">
-          <button
-            onClick={() => setLlmWizardOpen(true)}
-            className="px-4 py-2 text-sm bg-primary hover:bg-primary/90 text-primary-foreground rounded-lg transition-colors flex items-center gap-2"
-          >
-            <Bot className="w-4 h-4" />
-            {t('versionManagement.claude.installationButton')}
-          </button>
-        </div>
       </div>
 
       {/* Package Source Selector */}
@@ -1024,14 +1014,6 @@ export default function VersionManagementPage() {
         </DialogContent>
       </Dialog>
 
-      {/* LLM Installation Wizard Dialog */}
-      {llmWizardOpen && (
-        <InstallationWizard
-          manifestPath="/path/to/manifest.json"
-          onClose={() => setLlmWizardOpen(false)}
-          onComplete={() => setLlmWizardOpen(false)}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## 概要

- 移除版本管理页面中的「Claude 安装」按钮
- 移除 `InstallationWizard` 组件渲染及未使用的 `llmWizardOpen` 状态
- 清理未使用的 `InstallationWizard` 导入

## 动机

LLM 安装向导按钮使用了硬编码的占位路径（`/path/to/manifest.json`），导致运行时出现 `ENOENT` 文件不存在错误。同时 `llm:detect-config` IPC 通道缺少对应的 handler 注册，控制台持续输出 `No handler registered` 错误。该功能尚未就绪，移除入口可保持界面整洁并消除不必要的运行时错误。

## 变更文件

- `src/renderer/components/VersionManagementPage.tsx`
  - 移除 Claude 安装按钮
  - 移除 `InstallationWizard` 对话框渲染
  - 移除 `llmWizardOpen` 状态及 `InstallationWizard` 导入

## 测试

- [x] 版本管理页面正常渲染，无 Claude 安装按钮
- [x] 版本管理功能（安装、切换、卸载）无回归

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Claude installation UI button and installation wizard dialog from the version management page, streamlining the user interface while preserving underlying LLM functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->